### PR TITLE
Creates "Resources" directory if it doesn't exist.

### DIFF
--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -42,6 +42,12 @@ namespace Server
 
             if (!File.Exists(vTestFilePath))
             {
+                string vDirectoryName = Path.GetDirectoryName(vTestFilePath);
+                if (!Directory.Exists(vDirectoryName))
+                {
+                    Directory.CreateDirectory(vDirectoryName);
+                }
+
                 byte[] vArray = new byte[1048576];
                 using (FileStream vFileStream = File.Open(vTestFilePath, FileMode.Create, FileAccess.ReadWrite, FileShare.None))
                 {


### PR DESCRIPTION
When running the server for the first time, the "Resources" directory wasn't automatically created, raising an exception.